### PR TITLE
fix alias type output

### DIFF
--- a/domian/app/generate.go
+++ b/domian/app/generate.go
@@ -40,7 +40,7 @@ func (a *App) Generate() error {
 	gm.DoList(entityPkg.Parser.StructList)
 
 	for _, entry := range a.getEntries() {
-		gm.IOEntries(entityPkg.Parser.StructList, entry)
+		gm.IOEntries(entityPkg.Parser.StructList, entityPkg.Parser.AliasList, entry)
 	}
 
 	gm.EntityTypeDef()

--- a/domian/gen/hander.go
+++ b/domian/gen/hander.go
@@ -117,6 +117,7 @@ func (m *Manager) docs(entry string, modules []parser.EntryModule) error {
 		Pwd:          fmt.Sprintf("%s/%s/types", m.Tmpl.EntryDir, entry),
 		Package:      "types",
 		INFList:      make(map[string]parser.INF, 0),
+		AliasList:    make(map[string]parser.XField, 0),
 		StructList:   make(map[string]parser.XST, 0),
 		OtherStruct:  make(map[string]parser.XST, 0),
 		ConstStrList: make(map[string]string),

--- a/domian/gen/io.go
+++ b/domian/gen/io.go
@@ -13,12 +13,26 @@ import (
 	"github.com/xbitgo/core/tools/tool_file"
 )
 
-func (m *Manager) IOEntries(xsts map[string]parser.XST, entry string) {
+func (m *Manager) IOEntries(xsts map[string]parser.XST, alias map[string]parser.XField, entry string) {
 	var (
 		buf  = []byte{}
 		buf2 = []byte{}
 	)
-
+	//排序
+	aliasKeys := make([]string, 0, len(alias))
+	for k := range alias {
+		aliasKeys = append(aliasKeys, k)
+	}
+	sort.Strings(aliasKeys)
+	//顺序遍历
+	for _, k := range aliasKeys {
+		aliasField := alias[k]
+		b1, err := m.Alias(aliasField)
+		if err != nil {
+			log.Panicf("gen io err: %v \n", err)
+		}
+		buf = append(buf, b1...)
+	}
 	//排序
 	keys := make([]string, 0, len(xsts))
 	for k := range xsts {
@@ -59,6 +73,15 @@ func (m *Manager) IOEntries(xsts map[string]parser.XST, entry string) {
 	if err != nil {
 		log.Printf("io conv gen [%s] write file err: %v \n", filename, err)
 	}
+}
+
+func (m *Manager) Alias(alias parser.XField) ([]byte, error) {
+	a := tpls.Alias{
+		Name:    alias.Name,
+		Type:    alias.Type,
+		Comment: alias.Comment,
+	}
+	return a.Execute()
 }
 
 func (m *Manager) IO(xst parser.XST, tagName string) ([]byte, []byte, error) {

--- a/domian/gen/tpls/io.go
+++ b/domian/gen/tpls/io.go
@@ -5,6 +5,29 @@ import (
 	"text/template"
 )
 
+const aliasTpl = `
+type {{.Name}} {{.Type}} // {{.Comment}}
+`
+
+type Alias struct {
+	Name    string
+	Type    string
+	Comment string
+}
+
+func (s *Alias) Execute() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	tmpl, err := template.New(s.Name + "IO").Parse(aliasTpl)
+	if err != nil {
+		return nil, err
+	}
+	if err := tmpl.Execute(buf, s); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 const ioTpl = `
 type {{.Name}} struct{
 {{- range .Fields}}

--- a/domian/parser/parser.go
+++ b/domian/parser/parser.go
@@ -17,7 +17,8 @@ type IParser struct {
 	Pwd          string
 	Package      string
 	INFList      map[string]INF
-	StructList   map[string]XST
+	StructList   map[string]XST    // 结构体
+	AliasList    map[string]XField // 别名
 	OtherStruct  map[string]XST
 	ConstStrList map[string]string
 	BindFuncMap  map[string]map[string]XMethod

--- a/domian/parser/scanner.go
+++ b/domian/parser/scanner.go
@@ -27,6 +27,7 @@ func Scan(pwd string, parseType int) (ips *IParser, err error) {
 		Pwd:          pwd,
 		Package:      tool_str.LastPwdStr(pwd),
 		INFList:      make(map[string]INF, 0),
+		AliasList:    make(map[string]XField, 0),
 		StructList:   make(map[string]XST, 0),
 		OtherStruct:  make(map[string]XST, 0),
 		ConstStrList: make(map[string]string),
@@ -275,6 +276,16 @@ func (ips *IParser) ParseFile(pwd string) error {
 							}
 							inf.Methods = getInterfaceFunc(xt)
 							ips.INFList[name] = inf
+						case *ast.Ident:
+							xfd := XField{
+								Name:  name,
+								SType: STypeBasic,
+								Type:  xt.Name,
+							}
+							if xSpec.Comment != nil {
+								xfd.Comment = strings.Trim(xSpec.Comment.Text(), "\n")
+							}
+							ips.AliasList[name] = xfd
 						case *ast.StructType:
 							xst := XST{
 								GIName:     GIName,


### PR DESCRIPTION
在entity 中定义了结构体 

```go
type CloudCfgItemValue string
type CloudCfg struct {
	Node  string                        
	Items []map[string]CloudCfgItemValue 
}
```

生成的文件中缺失了 `CloudCfgItemValue `的定义。